### PR TITLE
Fix use of DateTime.Now and static Property handling in Parser & Inliner

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,20 +31,20 @@ You can checkout this Github repository or you can use the NuGet package:
 
 **Install using the command line from the Package Manager:**
 ```bash
-Install-Package SoloX.ExpressionTools.Parser -version 1.0.1-alpha.6
-Install-Package SoloX.ExpressionTools.Transform -version 1.0.1-alpha.6
+Install-Package SoloX.ExpressionTools.Parser -version 1.0.1-alpha.7
+Install-Package SoloX.ExpressionTools.Transform -version 1.0.1-alpha.7
 ```
 
 **Install using the .Net CLI:**
 ```bash
-dotnet add package SoloX.ExpressionTools.Parser --version 1.0.1-alpha.6
-dotnet add package SoloX.ExpressionTools.Transform --version 1.0.1-alpha.6
+dotnet add package SoloX.ExpressionTools.Parser --version 1.0.1-alpha.7
+dotnet add package SoloX.ExpressionTools.Transform --version 1.0.1-alpha.7
 ```
 
 **Install editing your project file (csproj):**
 ```xml
-<PackageReference Include="SoloX.ExpressionTools.Parser" Version="1.0.1-alpha.6" />
-<PackageReference Include="SoloX.ExpressionTools.Transform" Version="1.0.1-alpha.6" />
+<PackageReference Include="SoloX.ExpressionTools.Parser" Version="1.0.1-alpha.7" />
+<PackageReference Include="SoloX.ExpressionTools.Transform" Version="1.0.1-alpha.7" />
 ```
 
 ## How to use it

--- a/src/SharedProperties.props
+++ b/src/SharedProperties.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <Version>1.0.1-alpha.6</Version>
+    <Version>1.0.1-alpha.7</Version>
     <Authors>Xavier Solau</Authors>
     <Copyright>Copyright © 2019 Xavier Solau</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/libs/SoloX.ExpressionTools.Parser/Impl/Visitor/LambdaVisitor.cs
+++ b/src/libs/SoloX.ExpressionTools.Parser/Impl/Visitor/LambdaVisitor.cs
@@ -343,13 +343,29 @@ namespace SoloX.ExpressionTools.Parser.Impl.Visitor
 
             if (attribute.ResultingMethodInfo == null)
             {
-                MemberInfo member = type.GetProperty(memberName);
+                var property = type.GetProperty(memberName);
+                MemberInfo member = property;
+                var isStatic = false;
+
                 if (member == null)
                 {
-                    member = type.GetField(memberName);
+                    var field = type.GetField(memberName);
+                    member = field;
+                    isStatic = field.IsStatic;
+                }
+                else
+                {
+                    isStatic = property?.GetGetMethod()?.IsStatic ?? false;
                 }
 
-                attribute.ResultingExpression = Expression.MakeMemberAccess(exp, member);
+                if (isStatic)
+                {
+                    attribute.ResultingExpression = Expression.MakeMemberAccess(null, member);
+                }
+                else
+                {
+                    attribute.ResultingExpression = Expression.MakeMemberAccess(exp, member);
+                }
             }
             else
             {

--- a/src/libs/SoloX.ExpressionTools.Transform/Impl/Visitor/ConstantVisitor.cs
+++ b/src/libs/SoloX.ExpressionTools.Transform/Impl/Visitor/ConstantVisitor.cs
@@ -58,6 +58,12 @@ namespace SoloX.ExpressionTools.Transform.Impl.Visitor
 
                     return BuildConstantExpression(propertyInfo.PropertyType, value);
                 }
+                if (expNode == null)
+                {
+                    var value = propertyInfo.GetValue(null);
+
+                    return BuildConstantExpression(propertyInfo.PropertyType, value);
+                }
                 else
                 {
                     return Expression.MakeMemberAccess(expNode, propertyInfo);

--- a/src/tests/SoloX.ExpressionTools.Parser.UTest/ExpressionParserTest.cs
+++ b/src/tests/SoloX.ExpressionTools.Parser.UTest/ExpressionParserTest.cs
@@ -173,6 +173,8 @@ namespace SoloX.ExpressionTools.Parser.UTest
         [Theory(DisplayName = "It must parse DateTime lambda expression")]
         [InlineData("d => d > DateTime.Now.AddYears(-18)")]
         [InlineData("d => d > new DateTime(2021, 10, 01)")]
+        [InlineData("d => d > DateTime.Now")]
+        [InlineData("d => d > DateTime.Now.Date")]
         public void DateTimeParseTest(string stringExp)
         {
             var expParser = ExpressionParserHelper.CreateExpressionParser<DateTime>();

--- a/src/tests/SoloX.ExpressionTools.Transform.UTest/ConstantInlinerTest.cs
+++ b/src/tests/SoloX.ExpressionTools.Transform.UTest/ConstantInlinerTest.cs
@@ -91,6 +91,21 @@ namespace SoloX.ExpressionTools.Transform.UTest
         }
 
         [Fact]
+        public void IsShouldConvertExpressionWithStaticMember()
+        {
+            var inliner = new ConstantInliner();
+
+            Expression<Func<DateTime, bool>> expToInline = d => d < DateTime.Now.Date;
+
+            var exp = inliner.Amend(expToInline);
+            var txt = exp.Serialize();
+
+            var expected = $"d => (d < new DateTime({DateTime.Now.Ticks}).Date)";
+            Assert.StartsWith(expected.Substring(0, 30), txt, StringComparison.Ordinal);
+            Assert.EndsWith(").Date)", txt, StringComparison.Ordinal);
+        }
+
+        [Fact]
         public void IsShouldConvertExpressionWithConstDateTime()
         {
             var inliner = new ConstantInliner();


### PR DESCRIPTION
Bump to version 1.0.1-alpha.7